### PR TITLE
Moved `index_fcgi.php` out of webroot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add "PHPFastCGI Zend Framework 2 Adapter" to your application:
  
     php composer.phar require okeanrst/fastcgi-zf2-adapter
 
-Add in project directory below given file:
+Add the file below into the project directory:
 
 ```php
 <?php // fcgi.php
@@ -81,20 +81,20 @@ it should look something like below:
         root /var/www/FastCGIDaemonZF2/public;
 
         location / {
-        # try to serve file directly, fallback to app.php
-        try_files $uri /index.php$is_args$args;
-    }
+            # try to serve file directly, fallback to app.php
+            try_files $uri /index.php$is_args$args;
+        }
 
         location ~ ^/index\.php(/|$) {
-        fastcgi_pass workers;
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        include fastcgi_params;
+            fastcgi_pass workers;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
+            include fastcgi_params;
         
-        fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
-        fastcgi_param DOCUMENT_ROOT $realpath_root;
+            fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $realpath_root;
         
-        internal;
-    }
+            internal;
+        }
 
         error_log /var/log/nginx/fastcgi_zf2_error.log;
         access_log /var/log/nginx/fastcgi_zf2_access.log;

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Add "PHPFastCGI Zend Framework 2 Adapter" to your application:
  
     php composer.phar require okeanrst/fastcgi-zf2-adapter
 
-Add in `public` directory below given file:
+Add in project directory below given file:
 
 ```php
-<?php // public/index_fcgi.php
+<?php // fcgi.php
 
-chdir(dirname(__DIR__));
+chdir(__DIR__);
 
 // Setup autoloading
 require_once 'vendor/autoload.php';
@@ -39,10 +39,6 @@ $consoleApplication = (new ApplicationFactory)->createApplication($kernel);
 
 // Run the symfony console application
 $consoleApplication->run();
-
-
-// Include the composer autoloader
-require_once dirname(__FILE__) . '/../vendor/autoload.php';
 ```
 
 ### Supervisor setup
@@ -51,7 +47,7 @@ To setup supervisor, open your `/path/to/supervisor.d/`, create, eg, program_fas
 the following:
 
     [program:fastcgi_zf2_1]
-    command=php /var/www/FastCGIDaemonZF2/public/index_fcgi.php run --port=5001 --host=localhost
+    command=php /var/www/FastCGIDaemonZF2/fcgi.php run --port=5001 --host=localhost
     autostart=true
     autorestart=true
     stderr_logfile=/var/log/supervisor/fastcgi_zf2_1.err.log


### PR DESCRIPTION
Thanks very much for your work on this! :)

There's a few changes in here:
1. Moved `index_fcgi.php` out of webroot
2. Removed second require of composer autoloader (should only take one)
3. Fixed some indentation in NGINX configuration

The reason for the first change is that you don't want people to be able to start long running processes on the site just by visiting 'site.com/index_fcgi.php'. Moving it back a directory means that the developer is the only person that can start it :)

As a note: I haven't been able to test this and I've never used ZF2 before, so please have a check on your system before merging!
